### PR TITLE
Store user type from the home page based on ?view= value

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -12,6 +12,11 @@ router.use(function (req, res, next) {
   next()
 })
 
+router.get('/', function (req, res, next) {
+  req.session.data.pageView = req.query.view || 'operator'
+  next()
+})
+
 router.get('/account/:id/:page?/:subPage?', function (req, res, next) {
   res.locals['currentDate'] = Date.now()
   res.locals['installationID'] = req.params.id

--- a/app/views/app/dashboard.html
+++ b/app/views/app/dashboard.html
@@ -17,10 +17,19 @@
           iconFallbackText: 'Success'
         }) }}
     {% endif %}
-
+      {% set titleHTML %}
+      <span class="govuk-caption-xl">
+      {% if data['pageView'] == 'ea' %}
+        National Administrator
+      {% else %}
+       {{ data['pageView'] | capitalize }} account
+      {% endif %}
+      </span>
+      <h1 class="govuk-heading-xl">Your accounts</h1>
+      {% endset %}
     {{ hmctsPageHeaderWithActions({
       title: {
-        html: '<h1 class="govuk-heading-xl">Your accounts</h1>'
+        html: titleHTML
       },
       items: [{
         text: 'Add new installation',


### PR DESCRIPTION
Store user type from the home page based on ?view= value

By default value is 'operator' -> https://ets-alpha-5-pr-8.herokuapp.com/ then go to dashboard

pretend to be EA -> https://ets-alpha-5-pr-8.herokuapp.com?view=ea then go to the dashboard
